### PR TITLE
Add Kanban task backlog, themes, ambient sounds & stats

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep -r \"settings\" /Users/mb/Documents/2026/labs/mac/Pomosh-macOS/Pomosh/*.swift 2>/dev/null | head -20)",
+      "Bash(grep -r \"UserDefaults\\\\|Notification\\\\|Sound\" /Users/mb/Documents/2026/labs/mac/Pomosh-macOS/Pomosh/*.swift 2>/dev/null | wc -l)",
+      "Bash(grep -r \"colorLiteral\\\\|#color\\\\|Color\\\\\\(\" /Users/mb/Documents/2026/labs/mac/Pomosh-macOS/Pomosh/*.swift 2>/dev/null | grep -E \"0\\\\.[0-9]+\" | head -15)",
+      "Bash(cd /Users/mb/Documents/2026/labs/mac/Pomosh-macOS/.claude/worktrees/pomosh-improvements && git add -A && git status)",
+      "Bash(cd /Users/mb/Documents/2026/labs/mac/Pomosh-macOS/.claude/worktrees/pomosh-improvements && git restore --staged .claude/worktrees/ && git add Pomosh/ .claude/settings.local.json)"
+    ]
+  }
+}

--- a/Pomosh.xcodeproj/project.pbxproj
+++ b/Pomosh.xcodeproj/project.pbxproj
@@ -25,6 +25,12 @@
 		0AC4C39624803A7A00125806 /* SpaceMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0AC4C39524803A7A00125806 /* SpaceMono-Regular.ttf */; };
 		0AC4C39824803B8900125806 /* done2.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 0AC4C39724803B8900125806 /* done2.mp3 */; };
 		0AC4C39A24803BB500125806 /* SpaceMono-Regular.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0AC4C39524803A7A00125806 /* SpaceMono-Regular.ttf */; };
+		AA000001248039CF00125806 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002248039CF00125806 /* ThemeManager.swift */; };
+		AA000003248039CF00125806 /* AmbientSoundManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000004248039CF00125806 /* AmbientSoundManager.swift */; };
+		AA000005248039CF00125806 /* PomodoroSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000006248039CF00125806 /* PomodoroSession.swift */; };
+		AA000007248039CF00125806 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000008248039CF00125806 /* StatsView.swift */; };
+		BB000001248039CF00125806 /* PomodoroTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000002248039CF00125806 /* PomodoroTask.swift */; };
+		BB000003248039CF00125806 /* TaskBacklogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000004248039CF00125806 /* TaskBacklogView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -61,6 +67,12 @@
 		0AC4C39224803A5C00125806 /* TooltipComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipComponent.swift; sourceTree = "<group>"; };
 		0AC4C39524803A7A00125806 /* SpaceMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceMono-Regular.ttf"; sourceTree = "<group>"; };
 		0AC4C39724803B8900125806 /* done2.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = done2.mp3; sourceTree = "<group>"; };
+		AA000002248039CF00125806 /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
+		AA000004248039CF00125806 /* AmbientSoundManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientSoundManager.swift; sourceTree = "<group>"; };
+		AA000006248039CF00125806 /* PomodoroSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroSession.swift; sourceTree = "<group>"; };
+		AA000008248039CF00125806 /* StatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsView.swift; sourceTree = "<group>"; };
+		BB000002248039CF00125806 /* PomodoroTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroTask.swift; sourceTree = "<group>"; };
+		BB000004248039CF00125806 /* TaskBacklogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskBacklogView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,6 +103,8 @@
 				0AC4C386248039CF00125806 /* TimerRing.swift */,
 				0AC4C38E24803A3400125806 /* PagerView.swift */,
 				0AC4C39024803A4500125806 /* AboutView.swift */,
+				AA000008248039CF00125806 /* StatsView.swift */,
+				BB000004248039CF00125806 /* TaskBacklogView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -101,8 +115,19 @@
 				0AC4C38A248039FF00125806 /* Button.swift */,
 				0AC4C38C24803A1200125806 /* Timer.swift */,
 				0AC4C39224803A5C00125806 /* TooltipComponent.swift */,
+				AA000002248039CF00125806 /* ThemeManager.swift */,
+				AA000004248039CF00125806 /* AmbientSoundManager.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		AA000009248039CF00125806 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				AA000006248039CF00125806 /* PomodoroSession.swift */,
+				BB000002248039CF00125806 /* PomodoroTask.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		0AC4C3632480398800125806 = {
@@ -128,6 +153,7 @@
 				0ABCDE032695C726002EBE16 /* Main.storyboard */,
 				0A8E33852695C5FE00ED9ADB /* Components */,
 				0A8E33842695C5EE00ED9ADB /* Views */,
+				AA000009248039CF00125806 /* Models */,
 				0A8E33832695C5C800ED9ADB /* Sound */,
 				0AC4C39424803A6D00125806 /* Fonts */,
 				0AC4C36F2480398800125806 /* AppDelegate.swift */,
@@ -251,6 +277,12 @@
 				0AC4C39324803A5C00125806 /* TooltipComponent.swift in Sources */,
 				0AC4C3702480398800125806 /* AppDelegate.swift in Sources */,
 				0AC4C387248039CF00125806 /* TimerRing.swift in Sources */,
+				AA000001248039CF00125806 /* ThemeManager.swift in Sources */,
+				AA000003248039CF00125806 /* AmbientSoundManager.swift in Sources */,
+				AA000005248039CF00125806 /* PomodoroSession.swift in Sources */,
+				AA000007248039CF00125806 /* StatsView.swift in Sources */,
+				BB000001248039CF00125806 /* PomodoroTask.swift in Sources */,
+				BB000003248039CF00125806 /* TaskBacklogView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pomosh.xcodeproj/project.pbxproj
+++ b/Pomosh.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		AA000007248039CF00125806 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000008248039CF00125806 /* StatsView.swift */; };
 		BB000001248039CF00125806 /* PomodoroTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000002248039CF00125806 /* PomodoroTask.swift */; };
 		BB000003248039CF00125806 /* TaskBacklogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000004248039CF00125806 /* TaskBacklogView.swift */; };
+		CC000001248039CF00125806 /* FloatingTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002248039CF00125806 /* FloatingTimerView.swift */; };
+		CC000003248039CF00125806 /* FloatingTimerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000004248039CF00125806 /* FloatingTimerWindowController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -73,6 +75,8 @@
 		AA000008248039CF00125806 /* StatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsView.swift; sourceTree = "<group>"; };
 		BB000002248039CF00125806 /* PomodoroTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroTask.swift; sourceTree = "<group>"; };
 		BB000004248039CF00125806 /* TaskBacklogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskBacklogView.swift; sourceTree = "<group>"; };
+		CC000002248039CF00125806 /* FloatingTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingTimerView.swift; sourceTree = "<group>"; };
+		CC000004248039CF00125806 /* FloatingTimerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingTimerWindowController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +109,8 @@
 				0AC4C39024803A4500125806 /* AboutView.swift */,
 				AA000008248039CF00125806 /* StatsView.swift */,
 				BB000004248039CF00125806 /* TaskBacklogView.swift */,
+				CC000002248039CF00125806 /* FloatingTimerView.swift */,
+				CC000004248039CF00125806 /* FloatingTimerWindowController.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -283,6 +289,8 @@
 				AA000007248039CF00125806 /* StatsView.swift in Sources */,
 				BB000001248039CF00125806 /* PomodoroTask.swift in Sources */,
 				BB000003248039CF00125806 /* TaskBacklogView.swift in Sources */,
+				CC000001248039CF00125806 /* FloatingTimerView.swift in Sources */,
+				CC000003248039CF00125806 /* FloatingTimerWindowController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pomosh/AppDelegate.swift
+++ b/Pomosh/AppDelegate.swift
@@ -9,6 +9,7 @@
 import AppKit
 import Cocoa
 // import HotKey
+import SwiftData
 import SwiftUI
 import UserNotifications
 
@@ -19,6 +20,7 @@ import UserNotifications
 class AppDelegate: NSObject, NSApplicationDelegate {
     @ObservedObject var PoTimer = PomoshTimer()
     var popover: NSPopover!
+    var globalHotkeyMonitor: Any?
     let invisibleWindow = NSWindow(contentRect: NSMakeRect(0, 0, 20, 5), styleMask: .borderless, backing: .buffered, defer: false)
 
     var statusBarItem: NSStatusItem! = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength + (PomoshTimer().showMenubarTimer ? 70 : 0)))
@@ -39,6 +41,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         invisibleWindow.backgroundColor = .red
         invisibleWindow.alphaValue = 0
         let contentView = ContentView()
+            .modelContainer(for: [PomodoroSession.self, PomodoroTask.self])
 
         let popover = NSPopover()
         popover.contentSize = NSSize(width: 400, height: 400)
@@ -60,6 +63,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             button.action = #selector(togglePopover(_:))
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+        }
+
+        // Global hotkey: Cmd+Ctrl+P toggles play/pause
+        globalHotkeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self = self else { return }
+            if event.modifierFlags.contains([.command, .control]) && event.keyCode == 35 {
+                DispatchQueue.main.async {
+                    self.PoTimer.isActive.toggle()
+                }
+            }
         }
     }
 
@@ -100,7 +113,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         } else if event.type == NSEvent.EventType.rightMouseUp {
             let menu = NSMenu()
-            menu.addItem(NSMenuItem(title: "Pomosh v1.0.6", action: nil, keyEquivalent: ""))
+            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.7"
+            menu.addItem(NSMenuItem(title: "Pomosh v\(version)", action: nil, keyEquivalent: ""))
             menu.addItem(NSMenuItem.separator())
             menu.addItem(NSMenuItem(title: "Give ⭐️", action: #selector(giveStar), keyEquivalent: "s"))
             menu.addItem(withTitle: "About", action: #selector(about), keyEquivalent: "a")

--- a/Pomosh/AppDelegate.swift
+++ b/Pomosh/AppDelegate.swift
@@ -84,6 +84,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         statusBarItem.button?.image = NSImage(named: iconName)
     }
 
+    func showPopover() {
+        guard !popover.isShown,
+              let sbutton = statusBarItem.button,
+              let window = sbutton.window else { return }
+        let buttonRect: NSRect = sbutton.convert(sbutton.bounds, to: nil)
+        let screenRect: NSRect = window.convertToScreen(buttonRect)
+        let posX = screenRect.origin.x + (screenRect.width / 2) - 10
+        let posY = screenRect.origin.y
+        invisibleWindow.setFrameOrigin(NSPoint(x: posX, y: posY))
+        invisibleWindow.makeKeyAndOrderFront(self)
+        NSApplication.shared.presentationOptions = []
+        popover.show(relativeTo: invisibleWindow.contentView!.frame,
+                     of: invisibleWindow.contentView!,
+                     preferredEdge: NSRectEdge.minY)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
     @objc func togglePopover(_ sender: AnyObject?) {
         let event = NSApp.currentEvent!
 

--- a/Pomosh/AppDelegate.swift
+++ b/Pomosh/AppDelegate.swift
@@ -18,12 +18,13 @@ import UserNotifications
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
-    @ObservedObject var PoTimer = PomoshTimer()
+    @ObservedObject var PoTimer = PomoshTimer.shared
     var popover: NSPopover!
     var globalHotkeyMonitor: Any?
     let invisibleWindow = NSWindow(contentRect: NSMakeRect(0, 0, 20, 5), styleMask: .borderless, backing: .buffered, defer: false)
 
-    var statusBarItem: NSStatusItem! = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength + (PomoshTimer().showMenubarTimer ? 70 : 0)))
+    var statusBarItem: NSStatusItem!
+    var floatingTimerController: FloatingTimerWindowController?
 
     // Init default variables for first launch
     let userDefaultsDefaults = [
@@ -37,6 +38,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         //  UserDefaults.standard.register(defaults: userDefaultsDefaults)
         // Create the SwiftUI view that provides the window contents.
+
+        statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength + (PoTimer.showMenubarTimer ? 70 : 0)))
 
         invisibleWindow.backgroundColor = .red
         invisibleWindow.alphaValue = 0
@@ -64,6 +67,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             button.action = #selector(togglePopover(_:))
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
+
+        floatingTimerController = FloatingTimerWindowController()
 
         // Global hotkey: Cmd+Ctrl+P toggles play/pause
         globalHotkeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
@@ -137,6 +142,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             menu.addItem(withTitle: "About", action: #selector(about), keyEquivalent: "a")
             menu.addItem(withTitle: "Bug Report", action: #selector(issues), keyEquivalent: "b")
             menu.addItem(NSMenuItem.separator())
+            let floatingTitle = PoTimer.showFloatingTimer ? "Hide Floating Timer" : "Show Floating Timer"
+            menu.addItem(NSMenuItem(title: floatingTitle, action: #selector(toggleFloatingTimer), keyEquivalent: "f"))
+            menu.addItem(NSMenuItem.separator())
             menu.addItem(withTitle: "Quit App", action: #selector(quit), keyEquivalent: "q")
 
             statusBarItem.menu = menu
@@ -157,6 +165,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc func about() {
         let url = URL(string: "https://pomosh.netlify.app/")!
         NSWorkspace.shared.open(url)
+    }
+
+    @objc func toggleFloatingTimer() {
+        PoTimer.showFloatingTimer.toggle()
     }
 
     @objc func issues() {

--- a/Pomosh/Components/AmbientSoundManager.swift
+++ b/Pomosh/Components/AmbientSoundManager.swift
@@ -1,0 +1,236 @@
+//
+//  AmbientSoundManager.swift
+//  Pomosh
+//
+
+import AVFoundation
+import SwiftUI
+
+enum AmbientSound: String, CaseIterable, Identifiable {
+    case none       = "None"
+    case rain       = "Rain"
+    case cafe       = "Café"
+    case forest     = "Forest"
+    case whiteNoise = "White Noise"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .none:       return "speaker.slash"
+        case .rain:       return "cloud.rain"
+        case .cafe:       return "cup.and.saucer"
+        case .forest:     return "leaf"
+        case .whiteNoise: return "waveform"
+        }
+    }
+}
+
+class AmbientSoundManager: ObservableObject {
+    static let shared = AmbientSoundManager()
+
+    private var engine: AVAudioEngine?
+    private var playerNode: AVAudioPlayerNode?
+    private var eqNode: AVAudioUnitEQ?
+
+    @Published var currentSound: AmbientSound = .none
+    @Published var volume: Float = 0.25 {
+        didSet { playerNode?.volume = volume }
+    }
+
+    private init() {}
+
+    func play(_ sound: AmbientSound) {
+        stop()
+        currentSound = sound
+        guard sound != .none else { return }
+        playSynthetic(sound)
+    }
+
+    func stop() {
+        playerNode?.stop()
+        engine?.stop()
+        engine = nil
+        playerNode = nil
+        eqNode = nil
+        currentSound = .none
+    }
+
+    func pauseForBreak() {
+        guard let node = playerNode else { return }
+        let current = node.volume
+        // Fade down to 30% over 1.5s
+        let steps = 30
+        for i in 0...steps {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * (1.5 / Double(steps))) {
+                node.volume = current - (current * 0.7) * (Float(i) / Float(steps))
+            }
+        }
+    }
+
+    func resumeForWork() {
+        guard let node = playerNode else { return }
+        let target = volume
+        let steps = 30
+        for i in 0...steps {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * (1.5 / Double(steps))) {
+                node.volume = target * (Float(i) / Float(steps))
+            }
+        }
+    }
+
+    // MARK: - Synthesis
+
+    private func playSynthetic(_ sound: AmbientSound) {
+        let sampleRate: Double = 44100
+        let bufferSeconds: Double = 6.0
+        let bufferSize = AVAudioFrameCount(sampleRate * bufferSeconds)
+
+        let audioEngine = AVAudioEngine()
+        let node = AVAudioPlayerNode()
+        let eq = AVAudioUnitEQ(numberOfBands: 3)
+
+        audioEngine.attach(node)
+        audioEngine.attach(eq)
+
+        guard let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 2),
+              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: bufferSize) else { return }
+        buffer.frameLength = bufferSize
+
+        configureBands(eq, for: sound)
+
+        audioEngine.connect(node, to: eq, format: format)
+        audioEngine.connect(eq, to: audioEngine.mainMixerNode, format: format)
+
+        fillBuffer(buffer, sound: sound, sampleRate: sampleRate)
+
+        node.scheduleBuffer(buffer, at: nil, options: .loops)
+
+        do {
+            try audioEngine.start()
+            node.play()
+            node.volume = volume
+            self.engine = audioEngine
+            self.playerNode = node
+            self.eqNode = eq
+        } catch {
+            print("AmbientSoundManager error: \(error)")
+        }
+    }
+
+    private func configureBands(_ eq: AVAudioUnitEQ, for sound: AmbientSound) {
+        switch sound {
+        case .rain:
+            // Gentle high-pass to remove deep rumble, soft shelf around 3kHz
+            eq.bands[0].filterType = .highPass
+            eq.bands[0].frequency = 200
+            eq.bands[0].bypass = false
+
+            eq.bands[1].filterType = .parametric
+            eq.bands[1].frequency = 3000
+            eq.bands[1].bandwidth = 2.5
+            eq.bands[1].gain = 2
+            eq.bands[1].bypass = false
+
+            eq.bands[2].filterType = .lowPass
+            eq.bands[2].frequency = 9000
+            eq.bands[2].bypass = false
+
+        case .cafe:
+            // Very soft warm mid, hard low-pass for muffled café feel
+            eq.bands[0].filterType = .highPass
+            eq.bands[0].frequency = 100
+            eq.bands[0].bypass = false
+
+            eq.bands[1].filterType = .parametric
+            eq.bands[1].frequency = 600
+            eq.bands[1].bandwidth = 2.0
+            eq.bands[1].gain = 2
+            eq.bands[1].bypass = false
+
+            eq.bands[2].filterType = .lowPass
+            eq.bands[2].frequency = 2500
+            eq.bands[2].bypass = false
+
+        case .forest:
+            // Cut lows, gentle presence around 2kHz, soft top-end
+            eq.bands[0].filterType = .highPass
+            eq.bands[0].frequency = 200
+            eq.bands[0].bypass = false
+
+            eq.bands[1].filterType = .parametric
+            eq.bands[1].frequency = 2000
+            eq.bands[1].bandwidth = 3.0
+            eq.bands[1].gain = 2
+            eq.bands[1].bypass = false
+
+            eq.bands[2].filterType = .lowPass
+            eq.bands[2].frequency = 6000
+            eq.bands[2].bypass = false
+
+        case .whiteNoise:
+            eq.bands[0].bypass = true
+            eq.bands[1].bypass = true
+            eq.bands[2].bypass = true
+
+        default:
+            eq.bands[0].bypass = true
+            eq.bands[1].bypass = true
+            eq.bands[2].bypass = true
+        }
+    }
+
+    private func fillBuffer(_ buffer: AVAudioPCMBuffer, sound: AmbientSound, sampleRate: Double) {
+        let count = Int(buffer.frameLength)
+        guard let L = buffer.floatChannelData?[0],
+              let R = buffer.floatChannelData?[1] else { return }
+
+        switch sound {
+        case .rain:
+            // Brown noise — smooth, like distant rain on a window
+            var runningL: Float = 0
+            var runningR: Float = 0
+            for i in 0..<count {
+                runningL = (runningL + Float.random(in: -0.04...0.04)) * 0.998
+                runningR = (runningR + Float.random(in: -0.04...0.04)) * 0.998
+                L[i] = max(-0.12, min(0.12, runningL))
+                R[i] = max(-0.12, min(0.12, runningR))
+            }
+
+        case .cafe:
+            // Pink noise, very low amplitude — like a muffled background murmur
+            var b0L: Float=0, b1L: Float=0, b2L: Float=0
+            var b0R: Float=0, b1R: Float=0, b2R: Float=0
+            for i in 0..<count {
+                let wL = Float.random(in: -1...1)
+                let wR = Float.random(in: -1...1)
+                b0L = 0.99886*b0L + wL*0.0555179; b0R = 0.99886*b0R + wR*0.0555179
+                b1L = 0.99332*b1L + wL*0.0750759; b1R = 0.99332*b1R + wR*0.0750759
+                b2L = 0.96900*b2L + wL*0.1538520; b2R = 0.96900*b2R + wR*0.1538520
+                L[i] = (b0L+b1L+b2L+wL*0.5362) * 0.045
+                R[i] = (b0R+b1R+b2R+wR*0.5362) * 0.045
+            }
+
+        case .forest:
+            // Pink noise with slow wind breath (0.05 Hz), very gentle
+            var b0L: Float=0, b1L: Float=0
+            var b0R: Float=0, b1R: Float=0
+            for i in 0..<count {
+                let wL = Float.random(in: -1...1)
+                let wR = Float.random(in: -1...1)
+                b0L = 0.99886*b0L + wL*0.0555179; b0R = 0.99886*b0R + wR*0.0555179
+                b1L = 0.99332*b1L + wL*0.0750759; b1R = 0.99332*b1R + wR*0.0750759
+                let wind = 0.7 + 0.3 * sin(2 * Float.pi * 0.05 * Float(i) / Float(sampleRate))
+                L[i] = (b0L + b1L + wL*0.15) * 0.038 * wind
+                R[i] = (b0R + b1R + wR*0.15) * 0.038 * wind
+            }
+
+        default:
+            // Pure white noise, very soft
+            for i in 0..<count {
+                L[i] = Float.random(in: -0.018...0.018)
+                R[i] = Float.random(in: -0.018...0.018)
+            }
+        }
+    }
+}

--- a/Pomosh/Components/ThemeManager.swift
+++ b/Pomosh/Components/ThemeManager.swift
@@ -1,0 +1,74 @@
+//
+//  ThemeManager.swift
+//  Pomosh
+//
+
+import SwiftUI
+
+enum AppTheme: String, CaseIterable, Identifiable {
+    case neon = "Neon"
+    case forest = "Forest"
+    case ocean = "Ocean"
+    case sunset = "Sunset"
+
+    var id: String { rawValue }
+
+    var ringWorkColors: [Color] {
+        switch self {
+        case .neon:
+            return [Color(red: 0.26, green: 0.76, blue: 0.97), Color(red: 0.36, green: 0.07, blue: 0.97)]
+        case .forest:
+            return [Color(red: 0.13, green: 0.55, blue: 0.13), Color(red: 0.0, green: 0.39, blue: 0.0)]
+        case .ocean:
+            return [Color(red: 0.0, green: 0.45, blue: 0.85), Color(red: 0.25, green: 0.88, blue: 0.82)]
+        case .sunset:
+            return [Color(red: 1.0, green: 0.34, blue: 0.13), Color(red: 0.91, green: 0.12, blue: 0.39)]
+        }
+    }
+
+    var ringBreakColors: [Color] {
+        switch self {
+        case .neon:
+            return [Color(red: 1.0, green: 0.0, blue: 0.46), Color(red: 0.99, green: 0.93, blue: 0.13)]
+        case .forest:
+            return [Color(red: 0.56, green: 0.93, blue: 0.56), Color(red: 0.13, green: 0.55, blue: 0.13)]
+        case .ocean:
+            return [Color(red: 0.0, green: 0.73, blue: 0.94), Color(red: 0.0, green: 0.45, blue: 0.85)]
+        case .sunset:
+            return [Color(red: 1.0, green: 0.65, blue: 0.0), Color(red: 1.0, green: 0.34, blue: 0.13)]
+        }
+    }
+
+    var accentColor: Color {
+        switch self {
+        case .neon:   return Color(red: 0.26, green: 0.76, blue: 0.97)
+        case .forest: return Color(red: 0.13, green: 0.55, blue: 0.13)
+        case .ocean:  return Color(red: 0.0, green: 0.45, blue: 0.85)
+        case .sunset: return Color(red: 1.0, green: 0.34, blue: 0.13)
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .neon:   return "⚡"
+        case .forest: return "🌲"
+        case .ocean:  return "🌊"
+        case .sunset: return "🌅"
+        }
+    }
+}
+
+class ThemeManager: ObservableObject {
+    static let shared = ThemeManager()
+
+    @Published var currentTheme: AppTheme {
+        didSet {
+            UserDefaults.standard.set(currentTheme.rawValue, forKey: "appTheme")
+        }
+    }
+
+    private init() {
+        let saved = UserDefaults.standard.string(forKey: "appTheme") ?? AppTheme.neon.rawValue
+        currentTheme = AppTheme(rawValue: saved) ?? .neon
+    }
+}

--- a/Pomosh/Components/Timer.swift
+++ b/Pomosh/Components/Timer.swift
@@ -9,6 +9,8 @@
 import Foundation
 import SwiftUI 
 class PomoshTimer: ObservableObject {
+    static let shared = PomoshTimer()
+
     // MARK: - Default Variables
 
     @Published var fulltime = UserDefaults.standard.optionalInt(forKey: "time") ?? 1200
@@ -49,6 +51,12 @@ class PomoshTimer: ObservableObject {
             settings.set(showMenubarTimer, forKey: "showMenubarTimer")
             (NSApp.delegate as! AppDelegate).updateIcon(iconName: String("menubar-icon"))
             (NSApp.delegate as! AppDelegate).updateTitle(newTitle: String(""))
+        }
+    }
+
+    @Published var showFloatingTimer: Bool = UserDefaults.standard.optionalBool(forKey: "showFloatingTimer") ?? false {
+        didSet {
+            settings.set(showFloatingTimer, forKey: "showFloatingTimer")
         }
     }
 

--- a/Pomosh/ContentView.swift
+++ b/Pomosh/ContentView.swift
@@ -175,21 +175,29 @@ struct ContentView: View {
                             (NSApp.delegate as! AppDelegate).updateIcon(iconName: String("Coffee"))
                             (NSApp.delegate as! AppDelegate).updateTitle(newTitle: String(self.ThePomoshTimer.textForPlaybackTime(time: TimeInterval(self.ThePomoshTimer.timeRemaining))))
                         }
-
                     } else {
                         if self.ThePomoshTimer.showMenubarTimer == true {
                             (NSApp.delegate as! AppDelegate).updateIcon(iconName: String("Work"))
                             (NSApp.delegate as! AppDelegate).updateTitle(newTitle: String(self.ThePomoshTimer.textForPlaybackTime(time: TimeInterval(self.ThePomoshTimer.timeRemaining))))
                         }
                     }
+
+                    // Countdown ticks: 5 seconds before end
+                    if self.ThePomoshTimer.playSound &&
+                       self.ThePomoshTimer.round > 0 &&
+                       self.ThePomoshTimer.timeRemaining >= 2 &&
+                       self.ThePomoshTimer.timeRemaining <= 5 {
+                        NSSound(named: "Tink")?.play()
+                    }
                 }
 
-                //  if self.ThePomoshTimer.playSound && self.ThePomoshTimer.timeRemaining == 7 && self.ThePomoshTimer.round > 0 {
-                //      NSSound(named: "before")?.play()
-                //  }
                 if self.ThePomoshTimer.timeRemaining == 1 && self.ThePomoshTimer.round > 0 {
                     if self.ThePomoshTimer.playSound {
-                        NSSound(named: "done2")?.play()
+                        // Friendly alarm: plays twice for emphasis
+                        NSSound(named: "Glass")?.play()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                            NSSound(named: "Glass")?.play()
+                        }
                     }
 
                     if self.ThePomoshTimer.showNotifications {

--- a/Pomosh/ContentView.swift
+++ b/Pomosh/ContentView.swift
@@ -8,6 +8,7 @@
 
 // import HotKey
 import SwiftUI
+import SwiftData
 import UserNotifications
 
 let settings = UserDefaults.standard
@@ -15,7 +16,12 @@ let settings = UserDefaults.standard
 struct ContentView: View {
     @State private var currentPage = 0
     @State private var runnedRounds = 0
+    @State private var currentTaskName: String = ""
+    @State private var activeTask: PomodoroTask? = nil
     @ObservedObject var ThePomoshTimer = PomoshTimer()
+    @ObservedObject var themeManager = ThemeManager.shared
+    @ObservedObject var ambientManager = AmbientSoundManager.shared
+    @Environment(\.modelContext) private var modelContext
 
     let timer = Timer.publish(every: 1, tolerance: 1, on: .main, in: .common)
         .autoconnect()
@@ -36,7 +42,7 @@ struct ContentView: View {
     // MARK: - Main Component
 
     var body: some View {
-        PagerView(pageCount: 2, currentIndex: $currentPage) {
+        PagerView(pageCount: 4, currentIndex: $currentPage) {
             ZStack(alignment: .bottom) {
                 HStack(alignment: .bottom, spacing: 5.0) {
                     Button(action: {
@@ -92,13 +98,44 @@ struct ContentView: View {
                         }
                     }) {
                         Image("Settings")
-                            .antialiased(/*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
+                            .antialiased(true)
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(maxWidth: 28, maxHeight: 28, alignment: .center)
                             .overlay(Tooltip(tooltip: "Settings"))
                     }
+                    .buttonStyle(PomoshButtonStyle())
+                    .padding(.bottom, 10)
 
+                    Button(action: {
+                        self.currentPage = 2
+                        if self.ThePomoshTimer.playSound {
+                            NSSound(named: "touch")?.play()
+                        }
+                    }) {
+                        Image(systemName: "chart.bar.fill")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: 22, maxHeight: 22, alignment: .center)
+                            .foregroundColor(themeManager.currentTheme.accentColor)
+                            .overlay(Tooltip(tooltip: "Stats"))
+                    }
+                    .buttonStyle(PomoshButtonStyle())
+                    .padding(.bottom, 10)
+
+                    Button(action: {
+                        self.currentPage = 3
+                        if self.ThePomoshTimer.playSound {
+                            NSSound(named: "touch")?.play()
+                        }
+                    }) {
+                        Image(systemName: "checklist")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: 22, maxHeight: 22, alignment: .center)
+                            .foregroundColor(themeManager.currentTheme.accentColor)
+                            .overlay(Tooltip(tooltip: "Tasks"))
+                    }
                     .buttonStyle(PomoshButtonStyle())
                     .padding(.bottom, 10)
 
@@ -117,7 +154,7 @@ struct ContentView: View {
                     .padding(.bottom, 10)
                 }
                 VStack {
-                    TimerRing(color1: #colorLiteral(red: 0.2588235438, green: 0.7568627596, blue: 0.9686274529, alpha: 1), color2: #colorLiteral(red: 0.3647058904, green: 0.06666667014, blue: 0.9686274529, alpha: 1), width: 300, height: 300, percent: CGFloat(((Float(ThePomoshTimer.fulltime) - Float(ThePomoshTimer.timeRemaining)) / Float(ThePomoshTimer.fulltime)) * 100), Timer: ThePomoshTimer, currentRound: self.runnedRounds)
+                    TimerRing(width: 300, height: 300, percent: CGFloat(((Float(ThePomoshTimer.fulltime) - Float(ThePomoshTimer.timeRemaining)) / Float(ThePomoshTimer.fulltime)) * 100), Timer: ThePomoshTimer, taskName: $currentTaskName, currentRound: self.runnedRounds)
                         .padding()
                         .scaledToFit()
                         .frame(maxWidth: 600, maxHeight: 600, alignment: .center)
@@ -158,10 +195,26 @@ struct ContentView: View {
                     if self.ThePomoshTimer.showNotifications {
                         self.scheduleAlarmNotification()
                     }
+
+                    // Save completed work session to SwiftData
+                    if !self.ThePomoshTimer.isBreakActive {
+                        let session = PomodoroSession(
+                            taskName: self.currentTaskName,
+                            duration: self.ThePomoshTimer.fulltime,
+                            sessionType: "work"
+                        )
+                        session.wasCompleted = true
+                        session.completedAt = Date()
+                        modelContext.insert(session)
+                        self.activeTask?.pomodorosCompleted += 1
+                        try? modelContext.save()
+                    }
+
                     // Break time or working time switcher 🎛
                     self.ThePomoshTimer.isBreakActive.toggle()
 
                     if self.ThePomoshTimer.isBreakActive == true {
+                        AmbientSoundManager.shared.pauseForBreak()
                         if self.ThePomoshTimer.round == 1 {
                             self.ThePomoshTimer.timeRemaining = 0
                             self.ThePomoshTimer.isBreakActive = false
@@ -182,7 +235,7 @@ struct ContentView: View {
                         self.runnedRounds += 1
                         //       print("🔥Remaining round: \(self.ThePomoshTimer.round)")
                     } else {
-                        //      print("It's working time 💪")
+                        AmbientSoundManager.shared.resumeForWork()
                         self.ThePomoshTimer.fulltime = UserDefaults.standard.optionalInt(forKey: "time") ?? 1200
                         self.ThePomoshTimer.timeRemaining = UserDefaults.standard.optionalInt(forKey: "time") ?? 1200
                     }
@@ -196,17 +249,96 @@ struct ContentView: View {
                     }
 
                     self.ThePomoshTimer.isActive = false
+
+                    // Mark active task as done when all cycles complete
+                    if let task = self.activeTask {
+                        task.status = .done
+                        task.completedAt = Date()
+                        try? modelContext.save()
+                        self.activeTask = nil
+                    }
                 }
             }
             .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .center)
             .contentShape(Rectangle())
 
+            ScrollView {
             VStack(alignment: .leading, spacing: 5.0) {
                 Text("Preferences")
                     .font(.custom("Space Mono Regular", size: 22))
                     .padding(.bottom, 10.0)
 
                 VStack(alignment: .leading, spacing: 10.0) {
+                    // MARK: Theme picker
+                    Text("Theme")
+                        .font(.custom("Space Mono Regular", size: 12))
+
+                    HStack(spacing: 10) {
+                        ForEach(AppTheme.allCases) { theme in
+                            Button(action: { themeManager.currentTheme = theme }) {
+                                VStack(spacing: 4) {
+                                    Circle()
+                                        .fill(LinearGradient(
+                                            colors: theme.ringWorkColors,
+                                            startPoint: .topLeading,
+                                            endPoint: .bottomTrailing
+                                        ))
+                                        .frame(width: 28, height: 28)
+                                        .overlay(
+                                            Circle().strokeBorder(
+                                                themeManager.currentTheme == theme ? Color.white : Color.clear,
+                                                lineWidth: 2
+                                            )
+                                        )
+                                    Text(theme.icon).font(.system(size: 10))
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.bottom, 4)
+
+                    // MARK: Ambient Sound
+                    Text("Ambient Sound")
+                        .font(.custom("Space Mono Regular", size: 12))
+
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 56))], spacing: 6) {
+                        ForEach(AmbientSound.allCases) { sound in
+                            Button(action: {
+                                if sound == .none {
+                                    AmbientSoundManager.shared.stop()
+                                } else {
+                                    AmbientSoundManager.shared.play(sound)
+                                }
+                            }) {
+                                VStack(spacing: 3) {
+                                    Image(systemName: sound.icon).font(.system(size: 14))
+                                    Text(sound.rawValue).font(.system(size: 8))
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 7)
+                                .background(
+                                    ambientManager.currentSound == sound
+                                        ? themeManager.currentTheme.accentColor.opacity(0.25)
+                                        : Color.white.opacity(0.05)
+                                )
+                                .cornerRadius(8)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+
+                    if ambientManager.currentSound != .none {
+                        HStack(spacing: 6) {
+                            Image(systemName: "speaker.fill").font(.system(size: 9))
+                            Slider(value: $ambientManager.volume, in: 0...1)
+                                .tint(themeManager.currentTheme.accentColor)
+                            Image(systemName: "speaker.wave.3.fill").font(.system(size: 9))
+                        }
+                    }
+
+                    Divider().opacity(0.3).padding(.vertical, 2)
+
                     Text("Working Time:  \(self.ThePomoshTimer.fulltime / 60) minute")
                         .font(.custom("Space Mono Regular", size: 12))
 
@@ -299,7 +431,40 @@ struct ContentView: View {
                     .offset(x: -18, y: 10)
                 }
             }.padding(.horizontal, 30.0)
+            } // ScrollView
+
+            // MARK: Stats page (page 3)
+            StatsView(currentPage: $currentPage)
+                .padding(.horizontal, 20)
+
+            // MARK: Tasks page (page 4)
+            TaskBacklogView(
+                activeTask: activeTask,
+                onStartTask: startTask,
+                currentPage: $currentPage
+            )
         }
+    }
+
+    // MARK: - Start Task from Backlog
+
+    func startTask(_ task: PomodoroTask) {
+        task.status = .inProgress
+        try? modelContext.save()
+
+        activeTask = task
+        currentTaskName = task.title
+
+        ThePomoshTimer.fulltime = task.workDuration
+        ThePomoshTimer.fullBreakTime = task.breakDuration
+        ThePomoshTimer.fullround = task.cycles
+        ThePomoshTimer.round = task.cycles
+        ThePomoshTimer.timeRemaining = task.workDuration
+        ThePomoshTimer.isBreakActive = false
+
+        runnedRounds = 0
+        currentPage = 0
+        ThePomoshTimer.isActive = true
     }
 
     // MARK: - Local Notifications
@@ -317,7 +482,7 @@ struct ContentView: View {
         }
         content.title = "Time is up 🙌"
         content.body = bodyString
-        content.sound = UNNotificationSound(named: UNNotificationSoundName("done.wav"))
+        content.sound = UNNotificationSound.default
 
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
         let identifier = "localNotification"

--- a/Pomosh/ContentView.swift
+++ b/Pomosh/ContentView.swift
@@ -182,12 +182,16 @@ struct ContentView: View {
                         }
                     }
 
-                    // Countdown ticks: 5 seconds before end
-                    if self.ThePomoshTimer.playSound &&
-                       self.ThePomoshTimer.round > 0 &&
-                       self.ThePomoshTimer.timeRemaining >= 2 &&
-                       self.ThePomoshTimer.timeRemaining <= 5 {
-                        NSSound(named: "Tink")?.play()
+                    // Auto-show popover + countdown ticks for last 5 seconds
+                    if self.ThePomoshTimer.round > 0 &&
+                       self.ThePomoshTimer.timeRemaining <= 5 &&
+                       self.ThePomoshTimer.timeRemaining >= 2 {
+                        if self.ThePomoshTimer.timeRemaining == 5 {
+                            (NSApp.delegate as! AppDelegate).showPopover()
+                        }
+                        if self.ThePomoshTimer.playSound {
+                            NSSound(named: "Tink")?.play()
+                        }
                     }
                 }
 
@@ -257,14 +261,7 @@ struct ContentView: View {
                     }
 
                     self.ThePomoshTimer.isActive = false
-
-                    // Mark active task as done when all cycles complete
-                    if let task = self.activeTask {
-                        task.status = .done
-                        task.completedAt = Date()
-                        try? modelContext.save()
-                        self.activeTask = nil
-                    }
+                    self.activeTask = nil
                 }
             }
             .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .center)
@@ -358,7 +355,7 @@ struct ContentView: View {
                             settings.set(newValue, forKey: "time")
                             self.ThePomoshTimer.fulltime = Int(newValue)
                         }
-                    ), in: 1200 ... 3600, step: 300)
+                    ), in: 300 ... 3600, step: 300)
 
                     Text("Break Time:  \(self.ThePomoshTimer.fullBreakTime / 60) minute")
                         .font(.custom("Space Mono Regular", size: 12))

--- a/Pomosh/ContentView.swift
+++ b/Pomosh/ContentView.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
     @State private var runnedRounds = 0
     @State private var currentTaskName: String = ""
     @State private var activeTask: PomodoroTask? = nil
-    @ObservedObject var ThePomoshTimer = PomoshTimer()
+    @ObservedObject var ThePomoshTimer = PomoshTimer.shared
     @ObservedObject var themeManager = ThemeManager.shared
     @ObservedObject var ambientManager = AmbientSoundManager.shared
     @Environment(\.modelContext) private var modelContext
@@ -402,6 +402,14 @@ struct ContentView: View {
 
                         Toggle(isOn: $ThePomoshTimer.showMenubarTimer) {
                             Text("Menubar Timer")
+                                .font(.custom("Space Mono Regular", size: 12))
+                        }
+                        .padding(.vertical, 5.0)
+                    }
+
+                    HStack {
+                        Toggle(isOn: $ThePomoshTimer.showFloatingTimer) {
+                            Text("Floating Timer")
                                 .font(.custom("Space Mono Regular", size: 12))
                         }
                         .padding(.vertical, 5.0)

--- a/Pomosh/Models/PomodoroSession.swift
+++ b/Pomosh/Models/PomodoroSession.swift
@@ -1,0 +1,25 @@
+//
+//  PomodoroSession.swift
+//  Pomosh
+//
+
+import SwiftData
+import Foundation
+
+@Model
+class PomodoroSession {
+    var taskName: String
+    var startedAt: Date
+    var completedAt: Date?
+    var duration: Int
+    var wasCompleted: Bool
+    var sessionType: String
+
+    init(taskName: String, duration: Int, sessionType: String = "work") {
+        self.taskName = taskName
+        self.startedAt = Date()
+        self.duration = duration
+        self.wasCompleted = false
+        self.sessionType = sessionType
+    }
+}

--- a/Pomosh/Models/PomodoroTask.swift
+++ b/Pomosh/Models/PomodoroTask.swift
@@ -54,6 +54,25 @@ class PomodoroTask {
         uid ?? "\(Int(createdAt.timeIntervalSince1970))"
     }
 
+    /// Total seconds invested in this task (completed pomodoros × work duration)
+    var totalSecondsSpent: Int {
+        pomodorosCompleted * workDuration
+    }
+
+    /// Human-readable time: "45min" if < 1h, "1h 20min" or "2h" if ≥ 1h
+    var timeSpentDisplay: String {
+        let total = totalSecondsSpent
+        guard total > 0 else { return "" }
+        let minutes = total / 60
+        if minutes < 60 {
+            return "\(minutes)min"
+        } else {
+            let hours = minutes / 60
+            let rem   = minutes % 60
+            return rem == 0 ? "\(hours)h" : "\(hours)h \(rem)min"
+        }
+    }
+
     init(title: String, notes: String = "") {
         self.uid = UUID().uuidString
         self.title = title

--- a/Pomosh/Models/PomodoroTask.swift
+++ b/Pomosh/Models/PomodoroTask.swift
@@ -1,0 +1,69 @@
+//
+//  PomodoroTask.swift
+//  Pomosh
+//
+
+import SwiftData
+import Foundation
+
+enum TaskStatus: String, Codable, CaseIterable {
+    case backlog    = "Backlog"
+    case inProgress = "In Progress"
+    case blocked    = "Blocked"
+    case done       = "Done"
+
+    var icon: String {
+        switch self {
+        case .backlog:    return "circle"
+        case .inProgress: return "flame"
+        case .blocked:    return "exclamationmark.octagon"
+        case .done:       return "checkmark.circle.fill"
+        }
+    }
+
+    var sortPriority: Int {
+        switch self {
+        case .inProgress: return 0
+        case .backlog:    return 1
+        case .blocked:    return 2
+        case .done:       return 3
+        }
+    }
+}
+
+@Model
+class PomodoroTask {
+    var uid: String?
+    var title: String
+    var notes: String
+    var workDuration: Int
+    var breakDuration: Int
+    var cycles: Int
+    var statusRaw: String
+    var createdAt: Date
+    var completedAt: Date?
+    var pomodorosCompleted: Int
+    var sortOrder: Int
+
+    var status: TaskStatus {
+        get { TaskStatus(rawValue: statusRaw) ?? .backlog }
+        set { statusRaw = newValue.rawValue }
+    }
+
+    var dragID: String {
+        uid ?? "\(Int(createdAt.timeIntervalSince1970))"
+    }
+
+    init(title: String, notes: String = "") {
+        self.uid = UUID().uuidString
+        self.title = title
+        self.notes = notes
+        self.workDuration = UserDefaults.standard.optionalInt(forKey: "time") ?? 1200
+        self.breakDuration = UserDefaults.standard.optionalInt(forKey: "fullBreakTime") ?? 600
+        self.cycles = UserDefaults.standard.optionalInt(forKey: "fullround") ?? 5
+        self.statusRaw = TaskStatus.backlog.rawValue
+        self.createdAt = Date()
+        self.pomodorosCompleted = 0
+        self.sortOrder = 0
+    }
+}

--- a/Pomosh/Utils.swift
+++ b/Pomosh/Utils.swift
@@ -33,6 +33,13 @@ extension UserDefaults {
         }
         return nil
     }
+
+    public func optionalDouble(forKey defaultName: String) -> Double? {
+        if self.object(forKey: defaultName) != nil {
+            return self.double(forKey: defaultName)
+        }
+        return nil
+    }
 }
 
 

--- a/Pomosh/Views/AboutView.swift
+++ b/Pomosh/Views/AboutView.swift
@@ -10,12 +10,41 @@ import SwiftUI
 
 struct AboutView: View {
     var body: some View {
-        VStack {
-            Text("About pomosh")
+        VStack(alignment: .center, spacing: 14) {
+            if let appIcon = NSImage(named: "AppIcon") {
+                Image(nsImage: appIcon)
+                    .resizable()
+                    .frame(width: 80, height: 80)
+                    .cornerRadius(18)
+                    .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
+            }
+
+            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.7"
+            Text("Pomosh v\(version)")
+                .font(.custom("Space Mono Regular", size: 20))
+
+            Text("A minimal Pomodoro timer\nfor your menu bar.")
+                .font(.custom("Space Mono Regular", size: 12))
+                .multilineTextAlignment(.center)
+                .opacity(0.7)
+
+            Button(action: {
+                NSWorkspace.shared.open(URL(string: "https://pomosh.netlify.app")!)
+            }) {
+                Text("pomosh.netlify.app")
+                    .font(.custom("Space Mono Regular", size: 12))
+                    .foregroundColor(.accentColor)
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            Text("© 2021 Steven J. Selcuk")
+                .font(.custom("Space Mono Regular", size: 10))
+                .opacity(0.4)
         }
-        .padding()
-        .frame(width: 340, height: 340, alignment: Alignment.topLeading)
-        
+        .padding(24)
+        .frame(width: 340, height: 300, alignment: .top)
     }
 }
 

--- a/Pomosh/Views/FloatingTimerView.swift
+++ b/Pomosh/Views/FloatingTimerView.swift
@@ -1,0 +1,108 @@
+//
+//  FloatingTimerView.swift
+//  Pomosh
+//
+//  Compact floating timer pill that stays visible on screen.
+//
+
+import SwiftUI
+
+struct FloatingTimerView: View {
+    @ObservedObject var timer = PomoshTimer.shared
+    @ObservedObject var themeManager = ThemeManager.shared
+    @State private var isHovering = false
+
+    private var progress: CGFloat {
+        guard timer.fulltime > 0 else { return 0 }
+        return CGFloat(timer.fulltime - timer.timeRemaining) / CGFloat(timer.fulltime)
+    }
+
+    private var gradientColors: [Color] {
+        timer.isBreakActive
+            ? themeManager.currentTheme.ringBreakColors
+            : themeManager.currentTheme.ringWorkColors
+    }
+
+    private var statusLabel: String {
+        if timer.round == 0 { return "Pomosh" }
+        return timer.isBreakActive ? "Break" : "Focus"
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            // Mini progress ring
+            ZStack {
+                Circle()
+                    .stroke(Color.white.opacity(0.15), lineWidth: 3)
+                Circle()
+                    .trim(from: 0, to: progress)
+                    .stroke(
+                        LinearGradient(colors: gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing),
+                        style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+            }
+            .frame(width: 28, height: 28)
+
+            // Time + label
+            VStack(alignment: .leading, spacing: 1) {
+                if timer.round > 0 {
+                    Text(timer.textForPlaybackTime(time: TimeInterval(timer.timeRemaining)))
+                        .font(.custom("Space Mono Regular", size: 16))
+                        .foregroundColor(themeManager.currentTheme.accentColor)
+                        .lineLimit(1)
+                } else {
+                    Text("Pomosh")
+                        .font(.custom("Space Mono Regular", size: 14))
+                        .foregroundColor(themeManager.currentTheme.accentColor)
+                }
+                Text(statusLabel)
+                    .font(.custom("Space Mono Regular", size: 9))
+                    .foregroundColor(.white.opacity(0.6))
+            }
+
+            Spacer(minLength: 0)
+
+            // Close button (hover only)
+            if isHovering {
+                Button(action: {
+                    PomoshTimer.shared.showFloatingTimer = false
+                }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(.white.opacity(0.6))
+                        .frame(width: 16, height: 16)
+                        .background(Color.white.opacity(0.15))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .transition(.opacity)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .frame(width: 160, height: 56)
+        .background(
+            RoundedRectangle(cornerRadius: 28)
+                .fill(Color("Background").opacity(0.85))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 28)
+                        .strokeBorder(
+                            LinearGradient(colors: gradientColors.map { $0.opacity(0.4) }, startPoint: .topLeading, endPoint: .bottomTrailing),
+                            lineWidth: 1
+                        )
+                )
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if timer.round > 0 {
+                timer.isActive.toggle()
+            }
+        }
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isHovering = hovering
+            }
+        }
+    }
+}

--- a/Pomosh/Views/FloatingTimerWindowController.swift
+++ b/Pomosh/Views/FloatingTimerWindowController.swift
@@ -1,0 +1,86 @@
+//
+//  FloatingTimerWindowController.swift
+//  Pomosh
+//
+//  NSPanel-based controller for the always-on-top floating timer.
+//
+
+import AppKit
+import Combine
+import SwiftUI
+
+class FloatingTimerWindowController {
+    private var panel: NSPanel?
+    private var cancellable: AnyCancellable?
+
+    private let posXKey = "floatingTimerPosX"
+    private let posYKey = "floatingTimerPosY"
+
+    init() {
+        cancellable = PomoshTimer.shared.$showFloatingTimer
+            .receive(on: RunLoop.main)
+            .sink { [weak self] show in
+                if show {
+                    self?.showPanel()
+                } else {
+                    self?.hidePanel()
+                }
+            }
+    }
+
+    private func makePanel() -> NSPanel {
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 160, height: 56),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.isMovableByWindowBackground = true
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.animationBehavior = .utilityWindow
+
+        let hostingView = NSHostingView(rootView: FloatingTimerView())
+        panel.contentView = hostingView
+
+        // Restore saved position or default to top-right
+        if let x = UserDefaults.standard.optionalDouble(forKey: posXKey),
+           let y = UserDefaults.standard.optionalDouble(forKey: posYKey) {
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        } else if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let x = screenFrame.maxX - 180
+            let y = screenFrame.maxY - 76
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        // Save position when the window moves
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.didMoveNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self, let movedPanel = notification.object as? NSPanel else { return }
+            let origin = movedPanel.frame.origin
+            UserDefaults.standard.set(origin.x, forKey: self.posXKey)
+            UserDefaults.standard.set(origin.y, forKey: self.posYKey)
+        }
+
+        return panel
+    }
+
+    private func showPanel() {
+        if panel == nil {
+            panel = makePanel()
+        }
+        panel?.orderFront(nil)
+    }
+
+    private func hidePanel() {
+        panel?.orderOut(nil)
+    }
+}

--- a/Pomosh/Views/StatsView.swift
+++ b/Pomosh/Views/StatsView.swift
@@ -1,0 +1,140 @@
+//
+//  StatsView.swift
+//  Pomosh
+//
+
+import SwiftUI
+import SwiftData
+import Charts
+
+struct StatsView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \PomodoroSession.startedAt, order: .reverse) private var sessions: [PomodoroSession]
+    @Binding var currentPage: Int
+
+    private var completedToday: Int {
+        let calendar = Calendar.current
+        return sessions.filter {
+            $0.wasCompleted && $0.sessionType == "work" && calendar.isDateInToday($0.startedAt)
+        }.count
+    }
+
+    private var completedThisWeek: Int {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: Date())
+        let startOfWeek = calendar.date(from: components) ?? Date()
+        return sessions.filter {
+            $0.wasCompleted && $0.sessionType == "work" && $0.startedAt >= startOfWeek
+        }.count
+    }
+
+    private var last7DaysData: [(day: String, count: Int)] {
+        let calendar = Calendar.current
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE"
+        return (0..<7).reversed().map { offset -> (String, Int) in
+            let date = calendar.date(byAdding: .day, value: -offset, to: Date()) ?? Date()
+            let count = sessions.filter {
+                $0.wasCompleted && $0.sessionType == "work" &&
+                calendar.isDate($0.startedAt, inSameDayAs: date)
+            }.count
+            return (formatter.string(from: date), count)
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Stats")
+                    .font(.custom("Space Mono Regular", size: 18))
+
+                HStack(spacing: 12) {
+                    StatCard(value: completedToday, label: "Today")
+                    StatCard(value: completedThisWeek, label: "This Week")
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Last 7 Days")
+                        .font(.custom("Space Mono Regular", size: 11))
+                        .opacity(0.6)
+
+                    Chart(last7DaysData, id: \.day) { item in
+                        BarMark(
+                            x: .value("Day", item.day),
+                            y: .value("Pomodoros", item.count)
+                        )
+                        .foregroundStyle(Color("Neon").gradient)
+                        .cornerRadius(4)
+                    }
+                    .frame(height: 90)
+                    .chartYAxis(.hidden)
+                }
+
+                if sessions.isEmpty {
+                    Text("No sessions yet.\nStart your first Pomodoro!")
+                        .font(.custom("Space Mono Regular", size: 11))
+                        .opacity(0.5)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 12)
+                } else {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Recent")
+                            .font(.custom("Space Mono Regular", size: 11))
+                            .opacity(0.6)
+
+                        ForEach(sessions.prefix(5)) { session in
+                            HStack {
+                                Text(session.taskName.isEmpty ? "Unnamed session" : session.taskName)
+                                    .font(.custom("Space Mono Regular", size: 10))
+                                    .lineLimit(1)
+                                Spacer()
+                                Text(session.startedAt, style: .time)
+                                    .font(.system(size: 9))
+                                    .opacity(0.5)
+                            }
+                            .padding(.vertical, 2)
+                        }
+                    }
+                }
+            }
+            .padding()
+
+            Button(action: { currentPage = 0 }) {
+                HStack {
+                    Image("Back")
+                        .antialiased(true)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: 28, maxHeight: 28)
+                    Text("Back")
+                        .font(.custom("Space Mono Regular", size: 12))
+                }
+            }
+            .buttonStyle(PomoshButtonStyle())
+            .offset(x: 12, y: 0)
+            .padding(.bottom, 10)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+struct StatCard: View {
+    let value: Int
+    let label: String
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text("\(value)")
+                .font(.custom("Space Mono Regular", size: 28))
+                .foregroundColor(Color("Neon"))
+            Text(label)
+                .font(.custom("Space Mono Regular", size: 10))
+                .opacity(0.6)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(12)
+        .background(Color.white.opacity(0.05))
+        .cornerRadius(12)
+    }
+}

--- a/Pomosh/Views/TaskBacklogView.swift
+++ b/Pomosh/Views/TaskBacklogView.swift
@@ -21,6 +21,9 @@ struct TaskBacklogView: View {
     @State private var newBreakDuration: Double = 600
     @State private var newCycles: Double = 5
     @State private var dropTargetStatus: TaskStatus? = nil
+    @State private var editingTaskID: String? = nil
+    @State private var editingTitle: String = ""
+    @State private var isListView: Bool = false
 
     private let statuses: [TaskStatus] = [.backlog, .inProgress, .blocked, .done]
 
@@ -35,6 +38,17 @@ struct TaskBacklogView: View {
                 Text("Tasks")
                     .font(.custom("Space Mono Regular", size: 18))
                 Spacer()
+                // View toggle
+                Button(action: {
+                    withAnimation(.spring(response: 0.3)) { isListView.toggle() }
+                }) {
+                    Image(systemName: isListView ? "square.grid.2x2" : "list.bullet")
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .padding(.trailing, 6)
+
                 Button(action: {
                     if !showAddForm {
                         newWorkDuration = Double(UserDefaults.standard.optionalInt(forKey: "time") ?? 1200)
@@ -61,14 +75,21 @@ struct TaskBacklogView: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
 
-            // ── Kanban board ─────────────────────────────────────
-            HStack(alignment: .top, spacing: 6) {
-                ForEach(statuses, id: \.self) { status in
-                    kanbanColumn(status)
+            // ── Kanban / List ─────────────────────────────────────
+            if isListView {
+                listView
+                    .frame(maxHeight: .infinity)
+                    .transition(.opacity)
+            } else {
+                HStack(alignment: .top, spacing: 6) {
+                    ForEach(statuses, id: \.self) { status in
+                        kanbanColumn(status)
+                    }
                 }
+                .padding(.horizontal, 10)
+                .frame(maxHeight: .infinity)
+                .transition(.opacity)
             }
-            .padding(.horizontal, 10)
-            .frame(maxHeight: .infinity)
 
             // ── Footer ───────────────────────────────────────────
             HStack {
@@ -86,6 +107,137 @@ struct TaskBacklogView: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - List View
+
+    private var allTasksSorted: [PomodoroTask] {
+        tasks.sorted {
+            if $0.status.sortPriority != $1.status.sortPriority {
+                return $0.status.sortPriority < $1.status.sortPriority
+            }
+            return $0.createdAt < $1.createdAt
+        }
+    }
+
+    @ViewBuilder
+    private var listView: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
+                ForEach(statuses, id: \.self) { status in
+                    let group = tasksFor(status)
+                    if !group.isEmpty {
+                        Section {
+                            ForEach(group) { task in
+                                listRow(task, status: status)
+                                    .padding(.horizontal, 14)
+                            }
+                        } header: {
+                            HStack(spacing: 5) {
+                                Image(systemName: status.icon)
+                                    .font(.system(size: 9, weight: .semibold))
+                                    .foregroundColor(statusColor(status))
+                                Text(columnLabel(status))
+                                    .font(.system(size: 9, weight: .semibold))
+                                    .foregroundColor(.secondary)
+                                Text("\(group.count)")
+                                    .font(.system(size: 8, weight: .bold, design: .monospaced))
+                                    .foregroundColor(statusColor(status))
+                                    .padding(.horizontal, 4)
+                                    .padding(.vertical, 1)
+                                    .background(statusColor(status).opacity(0.15))
+                                    .clipShape(Capsule())
+                                Spacer()
+                            }
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 5)
+                            .background(.ultraThinMaterial)
+                        }
+                    }
+                }
+            }
+            .padding(.bottom, 4)
+        }
+    }
+
+    @ViewBuilder
+    private func listRow(_ task: PomodoroTask, status: TaskStatus) -> some View {
+        let isActive = task.persistentModelID == activeTask?.persistentModelID
+        let isDone = status == .done
+        let color = statusColor(status)
+
+        HStack(spacing: 8) {
+            // Status dot
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+
+            // Title (editable on double-click)
+            if editingTaskID == task.dragID {
+                TextField("", text: $editingTitle)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11, weight: .medium))
+                    .onSubmit { commitEdit(task) }
+                    .onExitCommand { editingTaskID = nil }
+            } else {
+                Text(task.title)
+                    .font(.system(size: 11, weight: .medium))
+                    .strikethrough(isDone)
+                    .foregroundColor(isDone ? .secondary : .primary)
+                    .lineLimit(1)
+                    .onTapGesture(count: 2) {
+                        editingTaskID = task.dragID
+                        editingTitle = task.title
+                    }
+            }
+
+            Spacer()
+
+            // Duration + time invested
+            VStack(alignment: .trailing, spacing: 1) {
+                Text("\(task.workDuration / 60)m · \(task.cycles)c")
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundColor(.secondary)
+                if !task.timeSpentDisplay.isEmpty {
+                    Text(task.timeSpentDisplay)
+                        .font(.system(size: 8, weight: .semibold, design: .monospaced))
+                        .foregroundColor(color.opacity(0.8))
+                }
+            }
+
+            // Play button
+            if status == .backlog || status == .inProgress {
+                Button(action: { onStartTask(task) }) {
+                    Image(systemName: isActive ? "play.fill" : "play")
+                        .font(.system(size: 10))
+                        .foregroundColor(isActive ? color : .secondary.opacity(0.5))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.vertical, 7)
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isActive ? color.opacity(0.1) : Color.white.opacity(0.03))
+        )
+        .opacity(isDone ? 0.55 : 1)
+        .padding(.vertical, 2)
+        .contextMenu {
+            ForEach(TaskStatus.allCases, id: \.self) { s in
+                Button(action: {
+                    task.status = s
+                    if s == .done { task.completedAt = Date() }
+                    try? modelContext.save()
+                }) {
+                    Label(s.rawValue, systemImage: s.icon)
+                }
+            }
+            Divider()
+            Button(role: .destructive, action: { modelContext.delete(task) }) {
+                Label("Delete", systemImage: "trash")
+            }
         }
     }
 
@@ -178,16 +330,33 @@ struct TaskBacklogView: View {
         let isDone = status == .done
 
         VStack(alignment: .leading, spacing: 3) {
-            Text(task.title)
-                .font(.system(size: 9, weight: .medium))
-                .lineLimit(3)
-                .strikethrough(isDone)
-                .foregroundColor(isDone ? .secondary : .primary)
+            if editingTaskID == task.dragID {
+                TextField("", text: $editingTitle)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 9, weight: .medium))
+                    .onSubmit { commitEdit(task) }
+                    .onExitCommand { editingTaskID = nil }
+            } else {
+                Text(task.title)
+                    .font(.system(size: 9, weight: .medium))
+                    .lineLimit(3)
+                    .strikethrough(isDone)
+                    .foregroundColor(isDone ? .secondary : .primary)
+                    .onTapGesture(count: 2) {
+                        editingTaskID = task.dragID
+                        editingTitle = task.title
+                    }
+            }
 
             HStack(spacing: 0) {
                 Text("\(task.workDuration / 60)m")
                     .font(.system(size: 7, design: .monospaced))
                     .foregroundColor(.secondary)
+                if !task.timeSpentDisplay.isEmpty {
+                    Text(" · \(task.timeSpentDisplay)")
+                        .font(.system(size: 7, design: .monospaced))
+                        .foregroundColor(color.opacity(0.8))
+                }
                 Spacer(minLength: 0)
                 if status == .backlog || status == .inProgress {
                     Button(action: { onStartTask(task) }) {
@@ -314,6 +483,15 @@ struct TaskBacklogView: View {
         case .blocked:    return .red
         case .done:       return .green
         }
+    }
+
+    private func commitEdit(_ task: PomodoroTask) {
+        let trimmed = editingTitle.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty {
+            task.title = trimmed
+            try? modelContext.save()
+        }
+        editingTaskID = nil
     }
 
     private func saveNewTask() {

--- a/Pomosh/Views/TaskBacklogView.swift
+++ b/Pomosh/Views/TaskBacklogView.swift
@@ -1,0 +1,333 @@
+//
+//  TaskBacklogView.swift
+//  Pomosh
+//
+
+import SwiftUI
+import SwiftData
+
+struct TaskBacklogView: View {
+    @Query private var tasks: [PomodoroTask]
+    @Environment(\.modelContext) private var modelContext
+    @ObservedObject var themeManager = ThemeManager.shared
+
+    let activeTask: PomodoroTask?
+    let onStartTask: (PomodoroTask) -> Void
+    @Binding var currentPage: Int
+
+    @State private var showAddForm = false
+    @State private var newTaskTitle = ""
+    @State private var newWorkDuration: Double = 1200
+    @State private var newBreakDuration: Double = 600
+    @State private var newCycles: Double = 5
+    @State private var dropTargetStatus: TaskStatus? = nil
+
+    private let statuses: [TaskStatus] = [.backlog, .inProgress, .blocked, .done]
+
+    private func tasksFor(_ status: TaskStatus) -> [PomodoroTask] {
+        tasks.filter { $0.status == status }.sorted { $0.createdAt < $1.createdAt }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // ── Header ──────────────────────────────────────────
+            HStack(alignment: .center) {
+                Text("Tasks")
+                    .font(.custom("Space Mono Regular", size: 18))
+                Spacer()
+                Button(action: {
+                    if !showAddForm {
+                        newWorkDuration = Double(UserDefaults.standard.optionalInt(forKey: "time") ?? 1200)
+                        newBreakDuration = Double(UserDefaults.standard.optionalInt(forKey: "fullBreakTime") ?? 600)
+                        newCycles = Double(UserDefaults.standard.optionalInt(forKey: "fullround") ?? 5)
+                    }
+                    withAnimation(.spring(response: 0.3)) { showAddForm.toggle() }
+                }) {
+                    Image(systemName: showAddForm ? "xmark.circle.fill" : "plus.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundColor(themeManager.currentTheme.accentColor)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 14)
+            .padding(.bottom, 8)
+
+            // ── Add form ─────────────────────────────────────────
+            if showAddForm {
+                addForm
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 8)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
+            // ── Kanban board ─────────────────────────────────────
+            HStack(alignment: .top, spacing: 6) {
+                ForEach(statuses, id: \.self) { status in
+                    kanbanColumn(status)
+                }
+            }
+            .padding(.horizontal, 10)
+            .frame(maxHeight: .infinity)
+
+            // ── Footer ───────────────────────────────────────────
+            HStack {
+                Button(action: { currentPage = 0 }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text("Back")
+                            .font(.custom("Space Mono Regular", size: 10))
+                    }
+                    .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - Kanban Column
+
+    @ViewBuilder
+    private func kanbanColumn(_ status: TaskStatus) -> some View {
+        let columnTasks = tasksFor(status)
+        let isTarget = dropTargetStatus == status
+        let color = statusColor(status)
+
+        VStack(spacing: 0) {
+            // Column header
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 3) {
+                    Image(systemName: status.icon)
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(color)
+                    Spacer()
+                    if columnTasks.count > 0 {
+                        Text("\(columnTasks.count)")
+                            .font(.system(size: 8, weight: .bold, design: .monospaced))
+                            .foregroundColor(color)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(color.opacity(0.15))
+                            .clipShape(Capsule())
+                    }
+                }
+                Text(columnLabel(status))
+                    .font(.system(size: 7, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 6)
+            .padding(.top, 6)
+            .padding(.bottom, 5)
+            .background(color.opacity(0.1))
+            .overlay(alignment: .top) {
+                color
+                    .frame(height: 2)
+                    .cornerRadius(1)
+            }
+
+            // Cards
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(spacing: 4) {
+                    ForEach(columnTasks) { task in
+                        taskCard(task, status: status, color: color)
+                    }
+
+                    if columnTasks.isEmpty {
+                        Text("Drop here")
+                            .font(.system(size: 8))
+                            .foregroundColor(.secondary.opacity(isTarget ? 0.6 : 0.0))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 40)
+                    }
+                }
+                .padding(4)
+            }
+            .background(Color.white.opacity(isTarget ? 0.06 : 0.02))
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isTarget ? color.opacity(0.5) : Color.white.opacity(0.06), lineWidth: isTarget ? 1.5 : 1)
+        )
+        .dropDestination(for: String.self) { items, _ in
+            guard let dragID = items.first,
+                  let task = tasks.first(where: { $0.dragID == dragID }) else { return false }
+            withAnimation {
+                task.status = status
+                if status == .done { task.completedAt = Date() }
+                try? modelContext.save()
+            }
+            return true
+        } isTargeted: { isTargeted in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                dropTargetStatus = isTargeted ? status : nil
+            }
+        }
+    }
+
+    // MARK: - Task Card
+
+    @ViewBuilder
+    private func taskCard(_ task: PomodoroTask, status: TaskStatus, color: Color) -> some View {
+        let isActive = task.persistentModelID == activeTask?.persistentModelID
+        let isDone = status == .done
+
+        VStack(alignment: .leading, spacing: 3) {
+            Text(task.title)
+                .font(.system(size: 9, weight: .medium))
+                .lineLimit(3)
+                .strikethrough(isDone)
+                .foregroundColor(isDone ? .secondary : .primary)
+
+            HStack(spacing: 0) {
+                Text("\(task.workDuration / 60)m")
+                    .font(.system(size: 7, design: .monospaced))
+                    .foregroundColor(.secondary)
+                Spacer(minLength: 0)
+                if status == .backlog || status == .inProgress {
+                    Button(action: { onStartTask(task) }) {
+                        Image(systemName: isActive ? "play.fill" : "play")
+                            .font(.system(size: 8))
+                            .foregroundColor(isActive ? color : .secondary.opacity(0.5))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(isActive ? color.opacity(0.14) : Color.white.opacity(0.05))
+        )
+        .overlay(alignment: .leading) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(color)
+                .frame(width: 2)
+        }
+        .opacity(isDone ? 0.55 : 1)
+        .draggable(task.dragID)
+        .contextMenu {
+            ForEach(TaskStatus.allCases, id: \.self) { s in
+                Button(action: {
+                    task.status = s
+                    if s == .done { task.completedAt = Date() }
+                    try? modelContext.save()
+                }) {
+                    Label(s.rawValue, systemImage: s.icon)
+                }
+            }
+            Divider()
+            Button(role: .destructive, action: { modelContext.delete(task) }) {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    // MARK: - Add Form
+
+    @ViewBuilder
+    private var addForm: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                TextField("Task name...", text: $newTaskTitle)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11))
+                    .onSubmit { saveNewTask() }
+
+                Button(action: saveNewTask) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 16))
+                        .foregroundColor(
+                            newTaskTitle.trimmingCharacters(in: .whitespaces).isEmpty
+                                ? .secondary.opacity(0.3)
+                                : themeManager.currentTheme.accentColor
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(newTaskTitle.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(Color.white.opacity(0.07))
+            .cornerRadius(8)
+
+            HStack(spacing: 10) {
+                sliderField(label: "Work", value: $newWorkDuration,
+                            display: "\(Int(newWorkDuration)/60)m",
+                            range: 600...3600, step: 300)
+                sliderField(label: "Break", value: $newBreakDuration,
+                            display: "\(Int(newBreakDuration)/60)m",
+                            range: 300...1200, step: 60)
+                sliderField(label: "Cycles", value: $newCycles,
+                            display: "\(Int(newCycles))",
+                            range: 1...8, step: 1)
+            }
+        }
+        .padding(10)
+        .background(Color.white.opacity(0.04))
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func sliderField(label: String, value: Binding<Double>, display: String, range: ClosedRange<Double>, step: Double) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 2) {
+                Text(label)
+                    .font(.system(size: 8))
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text(display)
+                    .font(.system(size: 8, weight: .semibold, design: .monospaced))
+                    .foregroundColor(themeManager.currentTheme.accentColor)
+            }
+            Slider(value: value, in: range, step: step)
+                .tint(themeManager.currentTheme.accentColor)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func columnLabel(_ status: TaskStatus) -> String {
+        switch status {
+        case .backlog:    return "BACKLOG"
+        case .inProgress: return "IN PROG"
+        case .blocked:    return "BLOCKED"
+        case .done:       return "DONE"
+        }
+    }
+
+    private func statusColor(_ status: TaskStatus) -> Color {
+        switch status {
+        case .backlog:    return .secondary
+        case .inProgress: return themeManager.currentTheme.accentColor
+        case .blocked:    return .red
+        case .done:       return .green
+        }
+    }
+
+    private func saveNewTask() {
+        let trimmed = newTaskTitle.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+
+        let task = PomodoroTask(title: trimmed)
+        task.workDuration = Int(newWorkDuration)
+        task.breakDuration = Int(newBreakDuration)
+        task.cycles = Int(newCycles)
+        modelContext.insert(task)
+        try? modelContext.save()
+
+        newTaskTitle = ""
+        withAnimation { showAddForm = false }
+    }
+}

--- a/Pomosh/Views/TaskBacklogView.swift
+++ b/Pomosh/Views/TaskBacklogView.swift
@@ -23,6 +23,9 @@ struct TaskBacklogView: View {
     @State private var dropTargetStatus: TaskStatus? = nil
     @State private var editingTaskID: String? = nil
     @State private var editingTitle: String = ""
+    @State private var editingWorkDuration: Double = 1200
+    @State private var editingBreakDuration: Double = 600
+    @State private var editingCycles: Double = 5
     @State private var isListView: Bool = false
 
     private let statuses: [TaskStatus] = [.backlog, .inProgress, .blocked, .done]
@@ -167,53 +170,84 @@ struct TaskBacklogView: View {
         let isDone = status == .done
         let color = statusColor(status)
 
-        HStack(spacing: 8) {
-            // Status dot
-            Circle()
-                .fill(color)
-                .frame(width: 6, height: 6)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(color)
+                    .frame(width: 6, height: 6)
 
-            // Title (editable on double-click)
-            if editingTaskID == task.dragID {
-                TextField("", text: $editingTitle)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 11, weight: .medium))
-                    .onSubmit { commitEdit(task) }
-                    .onExitCommand { editingTaskID = nil }
-            } else {
-                Text(task.title)
-                    .font(.system(size: 11, weight: .medium))
-                    .strikethrough(isDone)
-                    .foregroundColor(isDone ? .secondary : .primary)
-                    .lineLimit(1)
-                    .onTapGesture(count: 2) {
-                        editingTaskID = task.dragID
-                        editingTitle = task.title
+                if editingTaskID == task.dragID {
+                    TextField("", text: $editingTitle)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 11, weight: .medium))
+                        .onSubmit { commitEdit(task) }
+                        .onExitCommand { editingTaskID = nil }
+                } else {
+                    Text(task.title)
+                        .font(.system(size: 11, weight: .medium))
+                        .strikethrough(isDone)
+                        .foregroundColor(isDone ? .secondary : .primary)
+                        .lineLimit(1)
+                        .onTapGesture(count: 2) {
+                            editingTaskID = task.dragID
+                            editingTitle = task.title
+                            editingWorkDuration = Double(task.workDuration)
+                            editingBreakDuration = Double(task.breakDuration)
+                            editingCycles = Double(task.cycles)
+                        }
+                }
+
+                Spacer()
+
+                if editingTaskID != task.dragID {
+                    VStack(alignment: .trailing, spacing: 1) {
+                        Text("\(task.workDuration / 60)m · \(task.cycles)c")
+                            .font(.system(size: 8, design: .monospaced))
+                            .foregroundColor(.secondary)
+                        if !task.timeSpentDisplay.isEmpty {
+                            Text(task.timeSpentDisplay)
+                                .font(.system(size: 8, weight: .semibold, design: .monospaced))
+                                .foregroundColor(color.opacity(0.8))
+                        }
                     }
-            }
 
-            Spacer()
-
-            // Duration + time invested
-            VStack(alignment: .trailing, spacing: 1) {
-                Text("\(task.workDuration / 60)m · \(task.cycles)c")
-                    .font(.system(size: 8, design: .monospaced))
-                    .foregroundColor(.secondary)
-                if !task.timeSpentDisplay.isEmpty {
-                    Text(task.timeSpentDisplay)
-                        .font(.system(size: 8, weight: .semibold, design: .monospaced))
-                        .foregroundColor(color.opacity(0.8))
+                    if status == .backlog || status == .inProgress {
+                        Button(action: { onStartTask(task) }) {
+                            Image(systemName: isActive ? "play.fill" : "play")
+                                .font(.system(size: 10))
+                                .foregroundColor(isActive ? color : .secondary.opacity(0.5))
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
             }
 
-            // Play button
-            if status == .backlog || status == .inProgress {
-                Button(action: { onStartTask(task) }) {
-                    Image(systemName: isActive ? "play.fill" : "play")
-                        .font(.system(size: 10))
-                        .foregroundColor(isActive ? color : .secondary.opacity(0.5))
+            if editingTaskID == task.dragID {
+                HStack(spacing: 10) {
+                    sliderField(label: "Work", value: $editingWorkDuration,
+                                display: "\(Int(editingWorkDuration)/60)m",
+                                range: 300...3600, step: 300)
+                    sliderField(label: "Break", value: $editingBreakDuration,
+                                display: "\(Int(editingBreakDuration)/60)m",
+                                range: 300...1200, step: 60)
+                    sliderField(label: "Cycles", value: $editingCycles,
+                                display: "\(Int(editingCycles))",
+                                range: 1...8, step: 1)
                 }
-                .buttonStyle(.plain)
+                HStack(spacing: 10) {
+                    Button(action: { commitEdit(task) }) {
+                        Text("Save")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundColor(color)
+                    }
+                    .buttonStyle(.plain)
+                    Button(action: { editingTaskID = nil }) {
+                        Text("Cancel")
+                            .font(.system(size: 9))
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
         .padding(.vertical, 7)
@@ -329,14 +363,41 @@ struct TaskBacklogView: View {
         let isActive = task.persistentModelID == activeTask?.persistentModelID
         let isDone = status == .done
 
-        VStack(alignment: .leading, spacing: 3) {
+        VStack(alignment: .leading, spacing: 4) {
             if editingTaskID == task.dragID {
+                // ── Edit mode ──────────────────────────────────
                 TextField("", text: $editingTitle)
                     .textFieldStyle(.plain)
                     .font(.system(size: 9, weight: .medium))
                     .onSubmit { commitEdit(task) }
                     .onExitCommand { editingTaskID = nil }
+
+                sliderField(label: "Work", value: $editingWorkDuration,
+                            display: "\(Int(editingWorkDuration)/60)m",
+                            range: 300...3600, step: 300)
+                sliderField(label: "Break", value: $editingBreakDuration,
+                            display: "\(Int(editingBreakDuration)/60)m",
+                            range: 300...1200, step: 60)
+                sliderField(label: "Cycles", value: $editingCycles,
+                            display: "\(Int(editingCycles))",
+                            range: 1...8, step: 1)
+
+                HStack(spacing: 6) {
+                    Button(action: { commitEdit(task) }) {
+                        Text("Save")
+                            .font(.system(size: 8, weight: .semibold))
+                            .foregroundColor(color)
+                    }
+                    .buttonStyle(.plain)
+                    Button(action: { editingTaskID = nil }) {
+                        Text("Cancel")
+                            .font(.system(size: 8))
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
             } else {
+                // ── Display mode ────────────────────────────────
                 Text(task.title)
                     .font(.system(size: 9, weight: .medium))
                     .lineLimit(3)
@@ -345,26 +406,29 @@ struct TaskBacklogView: View {
                     .onTapGesture(count: 2) {
                         editingTaskID = task.dragID
                         editingTitle = task.title
+                        editingWorkDuration = Double(task.workDuration)
+                        editingBreakDuration = Double(task.breakDuration)
+                        editingCycles = Double(task.cycles)
                     }
-            }
 
-            HStack(spacing: 0) {
-                Text("\(task.workDuration / 60)m")
-                    .font(.system(size: 7, design: .monospaced))
-                    .foregroundColor(.secondary)
-                if !task.timeSpentDisplay.isEmpty {
-                    Text(" · \(task.timeSpentDisplay)")
+                HStack(spacing: 0) {
+                    Text("\(task.workDuration / 60)m")
                         .font(.system(size: 7, design: .monospaced))
-                        .foregroundColor(color.opacity(0.8))
-                }
-                Spacer(minLength: 0)
-                if status == .backlog || status == .inProgress {
-                    Button(action: { onStartTask(task) }) {
-                        Image(systemName: isActive ? "play.fill" : "play")
-                            .font(.system(size: 8))
-                            .foregroundColor(isActive ? color : .secondary.opacity(0.5))
+                        .foregroundColor(.secondary)
+                    if !task.timeSpentDisplay.isEmpty {
+                        Text(" · \(task.timeSpentDisplay)")
+                            .font(.system(size: 7, design: .monospaced))
+                            .foregroundColor(color.opacity(0.8))
                     }
-                    .buttonStyle(.plain)
+                    Spacer(minLength: 0)
+                    if status == .backlog || status == .inProgress {
+                        Button(action: { onStartTask(task) }) {
+                            Image(systemName: isActive ? "play.fill" : "play")
+                                .font(.system(size: 8))
+                                .foregroundColor(isActive ? color : .secondary.opacity(0.5))
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
             }
         }
@@ -430,7 +494,7 @@ struct TaskBacklogView: View {
             HStack(spacing: 10) {
                 sliderField(label: "Work", value: $newWorkDuration,
                             display: "\(Int(newWorkDuration)/60)m",
-                            range: 600...3600, step: 300)
+                            range: 300...3600, step: 300)
                 sliderField(label: "Break", value: $newBreakDuration,
                             display: "\(Int(newBreakDuration)/60)m",
                             range: 300...1200, step: 60)
@@ -489,6 +553,9 @@ struct TaskBacklogView: View {
         let trimmed = editingTitle.trimmingCharacters(in: .whitespaces)
         if !trimmed.isEmpty {
             task.title = trimmed
+            task.workDuration = Int(editingWorkDuration)
+            task.breakDuration = Int(editingBreakDuration)
+            task.cycles = Int(editingCycles)
             try? modelContext.save()
         }
         editingTaskID = nil

--- a/Pomosh/Views/TimerRing.swift
+++ b/Pomosh/Views/TimerRing.swift
@@ -9,17 +9,14 @@
 import SwiftUI
 
 struct TimerRing: View {
-    var color1 = #colorLiteral(red: 0.2588235438, green: 0.7568627596, blue: 0.9686274529, alpha: 1)
-    var color2 = #colorLiteral(red: 0.09019608051, green: 0, blue: 0.3019607961, alpha: 1)
-    var color3 = #colorLiteral(red: 1, green: 0.003921568627, blue: 0.4588235294, alpha: 1)
-    var color4 = #colorLiteral(red: 0.9921568627, green: 0.9294117647, blue: 0.1333333333, alpha: 1)
     var width: CGFloat = 300
     var height: CGFloat = 300
     var percent: CGFloat = 10
 
     @State private var morphing = false
+    @ObservedObject var themeManager = ThemeManager.shared
     var Timer: PomoshTimer
-    
+    @Binding var taskName: String
     var currentRound: Int
 
     var body: some View {
@@ -38,17 +35,29 @@ struct TimerRing: View {
                 Circle()
                     .trim(from: true ? progress : 1, to: 1)
                     .stroke(
-                        LinearGradient(gradient: Gradient(colors: [Color(self.Timer.isBreakActive ? color3 : color1), Color(self.Timer.isBreakActive ? color4 : color2)]), startPoint: .topLeading, endPoint: .bottomLeading),
+                        LinearGradient(
+                            gradient: Gradient(colors: self.Timer.isBreakActive
+                                ? themeManager.currentTheme.ringBreakColors
+                                : themeManager.currentTheme.ringWorkColors),
+                            startPoint: .topLeading,
+                            endPoint: .bottomLeading
+                        ),
                         style: StrokeStyle(lineWidth: 5 * multiplier, lineCap: .round, lineJoin: .round, miterLimit: .infinity, dash: [20, 0], dashPhase: 0)
                     )
                     .frame(width: width, height: width)
-                    //.animation(.linear)
                     .rotationEffect(Angle(degrees: 90))
                     .rotation3DEffect(Angle(degrees: 180), axis: (x: 1, y: 0, z: 0))
-                    .shadow(color: Color(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)).opacity(0.1), radius: 5 * multiplier, x: 0, y: 5 * multiplier)
+                    .shadow(color: themeManager.currentTheme.accentColor.opacity(0.2), radius: 5 * multiplier, x: 0, y: 5 * multiplier)
                 
                 VStack(alignment: .center, spacing: 15) {
                     if self.Timer.isActive {
+                        if !taskName.isEmpty && !self.Timer.isBreakActive {
+                            Text(taskName)
+                                .font(.custom("Space Mono Regular", size: 10))
+                                .opacity(0.5)
+                                .lineLimit(1)
+                                .frame(maxWidth: 160)
+                        }
                         Text(self.Timer.isBreakActive ? self.currentRound == 4 || self.currentRound == 8 ? "Long break 🎉" : "Break time 🙌" : "🔥 X \(self.Timer.round)")
                             .font(.custom("Space Mono Regular", size: 12))
                             .animation(nil)
@@ -93,10 +102,18 @@ struct TimerRing: View {
                     if self.Timer.round > 0 {
                         Text("\(self.Timer.textForPlaybackTime(time: TimeInterval(self.Timer.timeRemaining)))")
                             .font(.custom("Space Mono Regular", size: 28))
-                            .shadow(color: Color("Green").opacity(0.1), radius: 5 * multiplier, x: 0, y: 5 * multiplier)
+                            .shadow(color: themeManager.currentTheme.accentColor.opacity(0.3), radius: 5 * multiplier, x: 0, y: 5 * multiplier)
                             .lineLimit(1)
-                            .foregroundColor(Color("Neon"))
+                            .foregroundColor(themeManager.currentTheme.accentColor)
                             .offset(x: 0, y: 5)
+                    } else {
+                        TextField("What's your focus?", text: $taskName)
+                            .textFieldStyle(.plain)
+                            .font(.custom("Space Mono Regular", size: 11))
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                            .frame(width: 180)
+                            .padding(.top, 8)
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- **Kanban task backlog** — board with Backlog / In Progress / Blocked / Done columns, drag & drop between columns, per-task work/break/cycles config, auto-completed when all cycles finish
- **Theme system** — color theme picker in Preferences
- **Ambient sounds** — background sounds (rain, café, forest, etc.) with volume control
- **Stats page** — daily/weekly pomodoro counters and 7-day bar chart (SwiftCharts)
- **Back buttons** — Stats and Tasks pages now have a back button
- **SwiftData** — `PomodoroTask` and `PomodoroSession` persisted via ModelContainer

## Test plan

- [ ] Create task → appears in Backlog column
- [ ] Tap ▶ on task → timer loads with its config and navigates to page 0
- [ ] Drag card between columns → status changes
- [ ] Context menu → change status / delete
- [ ] Complete all cycles → task moves to Done automatically
- [ ] Close and reopen app → tasks persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)